### PR TITLE
Add test to make injectedhelpers compatible with all csharp language versions down to csharp 2

### DIFF
--- a/src/Stryker.Core/Stryker.Core.UnitTest/InjectedHelpers/InjectedHelperTests.cs
+++ b/src/Stryker.Core/Stryker.Core.UnitTest/InjectedHelpers/InjectedHelperTests.cs
@@ -1,23 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Pipes;
-using System.Linq;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Stryker.Core.InjectedHelpers;
+using System;
+using System.Collections.Generic;
+using System.IO.Pipes;
+using System.Linq;
 using Xunit;
 
 namespace Stryker.Core.UnitTest.InjectedHelpers
 {
     public class InjectedHelperTests
-    { 
+    {
         [Fact]
         public void InjectHelpers_ShouldCompile()
         {
             var assemblies = AppDomain.CurrentDomain.GetAssemblies();
             // it would be good to be ensure those assemblies are referenced by the build project
-            var needed = new[] {".CoreLib", ".Runtime", "System.IO.Pipes", ".Collections", ".Console" };
+            var needed = new[] { ".CoreLib", ".Runtime", "System.IO.Pipes", ".Collections", ".Console" };
             var references = new List<MetadataReference>();
             var hack = new NamedPipeClientStream("test");
             foreach (var assembly in assemblies)
@@ -37,6 +36,50 @@ namespace Stryker.Core.UnitTest.InjectedHelpers
             Assert.False(errors.Any(diag => diag.Severity == DiagnosticSeverity.Error));
         }
 
+        [Theory]
+        [InlineData(LanguageVersion.CSharp2)]
+        [InlineData(LanguageVersion.CSharp3)]
+        [InlineData(LanguageVersion.CSharp4)]
+        [InlineData(LanguageVersion.CSharp5)]
+        [InlineData(LanguageVersion.CSharp6)]
+        [InlineData(LanguageVersion.CSharp7)]
+        [InlineData(LanguageVersion.CSharp7_1)]
+        [InlineData(LanguageVersion.CSharp7_2)]
+        [InlineData(LanguageVersion.CSharp7_3)]
+        [InlineData(LanguageVersion.CSharp8)]
+        [InlineData(LanguageVersion.Default)]
+        [InlineData(LanguageVersion.Latest)]
+        [InlineData(LanguageVersion.LatestMajor)]
+        [InlineData(LanguageVersion.Preview)]
+        public void InjectHelpers_ShouldCompile_ForAllLanguageVersions(LanguageVersion version)
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
 
+            var needed = new[] { ".CoreLib", ".Runtime", "System.IO.Pipes", ".Collections", ".Console" };
+            var references = new List<MetadataReference>();
+            var hack = new NamedPipeClientStream("test");
+            foreach (var assembly in assemblies)
+            {
+                if (needed.Any(x => assembly.FullName.Contains(x)))
+                {
+                    references.Add(MetadataReference.CreateFromFile(assembly.Location));
+                }
+            }
+
+            var syntaxes = new List<SyntaxTree>();
+
+            foreach (var syntax in CodeInjection.MutantHelpers)
+            {
+                syntaxes.Add(CSharpSyntaxTree.ParseText(syntax.GetText(), new CSharpParseOptions(languageVersion: version)));
+            }
+
+            var compilation = CSharpCompilation.Create("dummy.dll",
+                syntaxes,
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary),
+                references: references);
+
+            var errors = compilation.GetDiagnostics();
+            Assert.False(errors.Any(diag => diag.Severity == DiagnosticSeverity.Error), string.Join("\n", errors.Where(diag => diag.Severity == DiagnosticSeverity.Error).Select(e => e.GetMessage())));
+        }
     }
 }

--- a/src/Stryker.Core/Stryker.Core/InjectedHelpers/MutantControl.cs
+++ b/src/Stryker.Core/Stryker.Core/InjectedHelpers/MutantControl.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using Stryker.Core.InjectedHelpers.Coverage;
+using System;
 using System.Collections.Generic;
-using Stryker.Core.InjectedHelpers.Coverage;
 
 namespace Stryker
 {
-    public static class MutantControl
+    public class MutantControl
     {
         private static HashSet<int> _coveredMutants;
         private static bool usePipe;
@@ -14,7 +14,7 @@ namespace Stryker
         private static CommunicationChannel channel;
 
         public const string EnvironmentPipeName = "Coverage";
-        
+
         static MutantControl()
         {
             InitCoverage();
@@ -29,10 +29,10 @@ namespace Stryker
             ActiveMutation = int.Parse(Environment.GetEnvironmentVariable("ActiveMutation") ?? "-1");
             if (channel != null)
             {
-                channel?.Dispose();
+                channel.Dispose();
                 channel = null;
             }
-            var coverageMode = Environment.GetEnvironmentVariable(EnvironmentPipeName)??string.Empty;
+            string coverageMode = Environment.GetEnvironmentVariable(EnvironmentPipeName) ?? string.Empty;
             if (coverageMode.StartsWith("pipe:"))
             {
                 pipeName = coverageMode.Substring(5);
@@ -76,7 +76,12 @@ namespace Stryker
             GC.KeepAlive(_coveredMutants);
         }
 
-        public static void DumpState(HashSet<int> state = null)
+        public static void DumpState()
+        {
+            DumpState(null);
+        }
+
+        public static void DumpState(HashSet<int> state)
         {
             string report;
             state = state ?? _coveredMutants;
@@ -85,13 +90,13 @@ namespace Stryker
                 report = string.Join(",", state);
             }
 
-            Console.WriteLine($"DumpState {state.Count}");
+            Console.WriteLine("DumpState " + state.Count);
             channel.SendText(report);
         }
 
         private static void Log(string message)
         {
-            Console.WriteLine($"[{DateTime.Now:HH:mm:ss.fff} DBG] {message}");
+            Console.WriteLine("["+DateTime.Now.ToString(":HH:mm:ss.fff") + " DBG]"+  message);
         }
 
         // check with: Stryker.MutantControl.IsActive(ID)
@@ -120,6 +125,6 @@ namespace Stryker
             return ActiveMutation == id;
         }
 
-        private static int ActiveMutation { get; set;}
+        public static int ActiveMutation;
     }
 }


### PR DESCRIPTION
Hey @dupdob 

I was working on stryker-mutator/stryker-net#568 and I realized that not all of our injected code might be compatible with all csharp language features so I wrote a test to check the injected code against all languages features. Since csharp lang version 1 does not even support generics I decided not to support that but I rewrote all other syntactic sugar in our injected helpers to be compatible with at least language version 2. It doesn't feel right to me to just push it on to your branch so I'll submit it as a PR instead.

Do you see any issues with the proposed changes?